### PR TITLE
Update some color variables for WCAG contrast

### DIFF
--- a/_mixins.scss
+++ b/_mixins.scss
@@ -83,7 +83,7 @@ $teal900: #014D40;
 
 // submit button colors
 $primaryColor: $red500;
-$secondaryColor: $grey350;
+$secondaryColor: $grey500;
 
 $inputColor: hsl(212, 25%, 50%);
 
@@ -107,7 +107,7 @@ $darkSelColor: $grey600;
 $errorColor: $red600;
 $warningColor: $yellow800;
 $successColor: $teal500;
-$noticeColor: $blue700;
+$noticeColor: $blue800;
 
 // UI element styles
 $smallBorderRadius: 3px;


### PR DESCRIPTION
### Description

Darkens `$secondaryColor` which is used for the background of secondary buttons, e.g. the "rebuild" button at `admin/utilities/project-config`.
![2 rebuild buttons; one with darker gray background color.](https://user-images.githubusercontent.com/17884198/101840652-5c048580-3af9-11eb-9a2f-84fecc1746d3.png)

Darkens `$noticeColor` which is used for notice text color, e.g. the notice text for environment variables at `/admin/settings/general`.
![2 notice texts; one with darker blue color.](https://user-images.githubusercontent.com/17884198/101841051-13010100-3afa-11eb-9c58-9814ef949bb0.png)




