### PR TITLE
Update for focus styles

### DIFF
--- a/_mixins.scss
+++ b/_mixins.scss
@@ -496,7 +496,7 @@ $checkboxSize: 16px;
 }
 
 @mixin input-focused-styles {
-  outline: none;
+  outline-color: transparent;
   border-color: transparentize($inputColor, 0.2);
 }
 
@@ -570,7 +570,7 @@ $checkboxSize: 16px;
 }
 
 @mixin select-input-focused-styles {
-  outline: none;
+  outline-color: transparent;
   background-color: transparentize($inputColor, 0.5);
 }
 

--- a/_mixins.scss
+++ b/_mixins.scss
@@ -99,6 +99,10 @@ $hairlineColor: transparentize($grey800, 0.9);
 $mediumHairlineColor: transparentize($grey600, 0.75);
 $darkHairlineColor: transparentize($grey400, 0.5);
 
+// focus colors
+$lightFocusColor: $blue600;
+$darkFocusColor: $blue700;
+
 // selection colors
 $lightSelColor: $grey200;
 $darkSelColor: $grey600;


### PR DESCRIPTION
### Description
Improves a11y for windows high contrast mode and adds new color variables to use for focus styles:

`$lightFocusColor`
!['categories' item in sidebar with blue outline.](https://user-images.githubusercontent.com/17884198/101857396-3f2d7980-3b1c-11eb-8ed6-166d325259ba.png)

`$darkFocusColor`
!['new widget' button with blue outline.](https://user-images.githubusercontent.com/17884198/101857404-418fd380-3b1c-11eb-82b6-fc929852d60b.png)


